### PR TITLE
Add button to optionally import from chess.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4288,6 +4288,11 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13530,6 +13535,14 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
           "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
         }
+      }
+    },
+    "react-toastify": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.0.3.tgz",
+      "integrity": "sha512-rv3koC7f9lKKSkdpYgo/TGzgWlrB/aaiUInF1DyV7BpiM4kyTs+uhu6/r8XDMtBY2FOIHK+FlK3Iv7OzpA/tCA==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4188,6 +4188,20 @@
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
       "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
+    "chess-web-api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/chess-web-api/-/chess-web-api-1.1.0.tgz",
+      "integrity": "sha512-4CzyEQfIqE58Nbl8w+TbzctXTUcjx55kflKrAvqx41BG5ZDDsZW9FHex+LcxVTLmqMa9O29W6IqC3kh6j7xLpQ==",
+      "requires": {
+        "chess.js": "^0.11.0",
+        "superagent": "^5.2.1"
+      }
+    },
+    "chess.js": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-0.11.0.tgz",
+      "integrity": "sha512-yTpi6XbRMkBtnjSvbt6wEp9Y7JzhJl1MC3GNn67q5ClyccXxCRf5cMPSUg4OblrUapg1kLHm7WzxxEVp20NK1Q=="
+    },
     "chokidar": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -4507,6 +4521,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -6955,6 +6974,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "fastq": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
@@ -7242,6 +7266,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.2.0",
@@ -15405,6 +15434,49 @@
             "dot-prop": "^5.2.0",
             "indexes-of": "^1.0.1",
             "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "superagent": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
+      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
+    "react-toastify": "^8.0.3",
     "sass": "^1.36.0",
     "simple-statistics": "^7.7.0",
     "web-vitals": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.8.3",
     "axios": "^0.21.1",
     "bootstrap": "^5.0.2",
+    "chess-web-api": "^1.1.0",
     "d3": "^7.0.0",
     "node-sass": "^6.0.1",
     "react": "^17.0.2",

--- a/src/components/formGroup/ChessForm.js
+++ b/src/components/formGroup/ChessForm.js
@@ -61,7 +61,7 @@ export default function ChessForm({players, setPlayers}) {
         {(submitted === true) ? (<h2>Thank you for your submission. Go to the <Link to='/graphs'>Graphs section</Link> to see a comparison of each rating.</h2>): (<Form onSubmit={submitRecord}>
         <h2 id='chessFormH2'>Add your ratings to our data and <Link to='/graphs'>start comparing</Link>.</h2>
         <Form.Group>
-            <Form.Label className='mx-2 question'>FIDE membership?</Form.Label>
+            <Form.Label className='mx-2 question'>Do you have a FIDE membership?</Form.Label>
             <Form.Check inline label='Yes' value={true} type='radio' className = 'mx-2' name='FIDE'  onClick = {()=>{setFide(true)}}/>
             <Form.Check inline label='No' value ={false} name='FIDE'  type='radio' className = 'mx-2' defaultChecked  onClick={()=>{setFide(false)}}  />
         </Form.Group>

--- a/src/components/formGroup/ChessForm.js
+++ b/src/components/formGroup/ChessForm.js
@@ -61,7 +61,7 @@ export default function ChessForm({players, setPlayers}) {
         {(submitted === true) ? (<h2>Thank you for your submission. Go to the <Link to='/graphs'>Graphs section</Link> to see a comparison of each rating.</h2>): (<Form onSubmit={submitRecord}>
         <h2 id='chessFormH2'>Add your ratings to our data and <Link to='/graphs'>start comparing</Link>.</h2>
         <Form.Group>
-            <Form.Label className='mx-2 question'>Do you have a FIDE membership?</Form.Label>
+            <Form.Label className='mx-2 question'>FIDE membership?</Form.Label>
             <Form.Check inline label='Yes' value={true} type='radio' className = 'mx-2' name='FIDE'  onClick = {()=>{setFide(true)}}/>
             <Form.Check inline label='No' value ={false} name='FIDE'  type='radio' className = 'mx-2' defaultChecked  onClick={()=>{setFide(false)}}  />
         </Form.Group>
@@ -84,7 +84,7 @@ export default function ChessForm({players, setPlayers}) {
             <Form.Check inline label='No' name='Chesscom'  type='radio' className = 'mx-2' defaultChecked onClick={()=>{setChesscom(false)}}/>
         </Form.Group>
 
-        {Chesscom && <MembershipForm inputs={['bullet', 'blitz', 'rapid', 'daily', 'puzzle']} name='ChessCom'  record={record} setRecord={setRecord}/>}
+        {Chesscom && <MembershipForm inputs={['bullet', 'blitz', 'rapid', 'daily', 'puzzle']} name='ChessCom' record={record} setRecord={setRecord} allowImport={true}/>}
         <hr/>
 
         <Form.Group>

--- a/src/components/formGroup/ImportButtonGroup.js
+++ b/src/components/formGroup/ImportButtonGroup.js
@@ -1,0 +1,51 @@
+import React, {useState} from 'react'
+import {Form, Button} from 'react-bootstrap'
+import ChessWebAPI from 'chess-web-api'
+
+export default function ImportButtonGroup() {
+
+    const [username, setUsername] = useState('')
+
+    const handleUsernameChange = (e) => {
+        const usernameInput = e.target.value;
+        setUsername(usernameInput.trim())
+    }
+
+    const importFromChessCom = (e) => {
+      e.preventDefault();
+
+      const chessAPI = new ChessWebAPI();
+      chessAPI.getPlayerStats(username).then(
+        function (response) {
+          console.log("Player Profile", response.body, username);
+        },
+        function (err) {
+          console.error(err);
+        }
+      );
+    }
+
+    return (
+      <div className='ml-3 fade-in'>
+            <div className='import-container'>
+
+              <Button 
+                id='importButton' 
+                disabled={username === ''}
+                variant='dark' 
+                onClick={importFromChessCom}>
+                Import
+              </Button>
+
+              <Form.Control 
+                value={username} 
+                onChange={handleUsernameChange} 
+                placeholder='Username' 
+                type='text'
+              ></Form.Control>
+
+            </div>
+            <div className='import-button-separator'> - or - </div>
+      </div>
+    );
+}

--- a/src/components/formGroup/ImportButtonGroup.js
+++ b/src/components/formGroup/ImportButtonGroup.js
@@ -1,10 +1,10 @@
 import React, {useState} from 'react'
 import {Form, Button} from 'react-bootstrap'
-import ChessWebAPI from 'chess-web-api'
 import { ToastContainer, toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
+import ChessWebAPI from 'chess-web-api'
 
-export default function ImportButtonGroup() {
+export default function ImportButtonGroup({importedPlayerStats}) {
 
     const [username, setUsername] = useState('')
 
@@ -19,11 +19,10 @@ export default function ImportButtonGroup() {
       const chessAPI = new ChessWebAPI();
       chessAPI.getPlayerStats(username).then(
         function (response) {
-          console.log("Player Profile", response.body, username)
           toast.success('Import successful')
+          importedPlayerStats(response.body);
         },
         function (err) {
-          console.error(err);
           if (err.statusCode === 404) {
             toast.error(`Could not find name ${username}`)
           } else {

--- a/src/components/formGroup/ImportButtonGroup.js
+++ b/src/components/formGroup/ImportButtonGroup.js
@@ -1,6 +1,8 @@
 import React, {useState} from 'react'
 import {Form, Button} from 'react-bootstrap'
 import ChessWebAPI from 'chess-web-api'
+import { ToastContainer, toast } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 export default function ImportButtonGroup() {
 
@@ -17,10 +19,16 @@ export default function ImportButtonGroup() {
       const chessAPI = new ChessWebAPI();
       chessAPI.getPlayerStats(username).then(
         function (response) {
-          console.log("Player Profile", response.body, username);
+          console.log("Player Profile", response.body, username)
+          toast.success('Import successful')
         },
         function (err) {
           console.error(err);
+          if (err.statusCode === 404) {
+            toast.error(`Could not find name ${username}`)
+          } else {
+            toast.error('Could not import stats')
+          }
         }
       );
     }
@@ -46,6 +54,9 @@ export default function ImportButtonGroup() {
 
             </div>
             <div className='import-button-separator'> - or - </div>
+            <ToastContainer 
+              closeOnClick
+            />
       </div>
     );
 }

--- a/src/components/formGroup/MembershipForm.js
+++ b/src/components/formGroup/MembershipForm.js
@@ -2,10 +2,28 @@ import React, {useState, useEffect} from 'react'
 import {Form} from 'react-bootstrap'
 import RatingInput from './RatingInput'
 import ImportButtonGroup from './ImportButtonGroup'
+import { toast } from 'react-toastify'
 
 export default function MembershipForm({inputs, name, record, setRecord, allowImport}) {
 
     const [display, setDisplay] = useState({})
+
+    const importedPlayerStats = (stats) => {
+      const newRecord = { ...record };
+      newRecord[name] = {
+        bullet: stats.chess_bullet?.last?.rating,
+        blitz: stats.chess_blitz?.last?.rating,
+        rapid: stats.chess_rapid?.last?.rating,
+        daily: stats.chess_daily?.last?.rating,
+        puzzle: stats.tactics?.highest?.rating,
+      };
+
+      if (!validateRatingsOverMinimum(newRecord[name])) {
+        toast.warning("All ratings are below 500");
+      }
+      setRecord(newRecord);
+      setDisplayFromRating(newRecord)
+    };
 
     useEffect(()=>{
       if(Object.keys(display).length === 0){
@@ -23,13 +41,25 @@ export default function MembershipForm({inputs, name, record, setRecord, allowIm
           setDisplay(newDisplay)
     }
 
+    const validateRatingsOverMinimum = (inputRecord) => {
+      return Object.keys(inputRecord).filter((key) => inputRecord[key] >= 500).length > 0
+    }
+
+    const setDisplayFromRating = (inputRecord) => {
+      const newDisplay = {};
+      inputs.forEach((input) => {
+        newDisplay[name + input] = inputRecord[name][input] ? true : false;
+      });
+      setDisplay(newDisplay);
+    }
+
     const questions=inputs.map(input => {
         return (
             <div className='question' key={name+input}>
                 <Form.Group>
                     <Form.Label className='mx-2'>Do you have a {name} {input} rating?</Form.Label>
-                    <Form.Check inline label='Yes' value={true} name={name+input} type='radio' className = 'mx-2' onClick ={() =>{editDisplay(input, true)}} />
-                    <Form.Check inline label='No' value ={false} name={name+input}  type='radio' className = 'mx-2' defaultChecked onClick = {() =>{editDisplay(input, false)}}  />
+                    <Form.Check inline label='Yes' checked={display[name+input]} name={name+input} type='radio' className='mx-2' onClick={() =>{editDisplay(input, true)}} />
+                    <Form.Check inline label='No' checked={!display[name+input]} name={name+input}  type='radio' className='mx-2' onClick={() =>{editDisplay(input, false)}}  />
                 </Form.Group>
                 {display[name+input] && <RatingInput input={input} name={name} record={record} setRecord={setRecord}/>}
                 
@@ -40,7 +70,7 @@ export default function MembershipForm({inputs, name, record, setRecord, allowIm
     return (
       <div className='ml-3 fade-in'>
         {allowImport && (
-          <ImportButtonGroup/>
+          <ImportButtonGroup importedPlayerStats={importedPlayerStats} />
         )}
         {questions}
       </div>

--- a/src/components/formGroup/MembershipForm.js
+++ b/src/components/formGroup/MembershipForm.js
@@ -1,12 +1,13 @@
 import React, {useState, useEffect} from 'react'
 import {Form} from 'react-bootstrap'
 import RatingInput from './RatingInput'
+import ImportButtonGroup from './ImportButtonGroup'
 
-export default function MembershipForm({inputs, name, record, setRecord}) {
+export default function MembershipForm({inputs, name, record, setRecord, allowImport}) {
 
-  const [display, setDisplay] = useState({})
+    const [display, setDisplay] = useState({})
 
-  useEffect(()=>{
+    useEffect(()=>{
       if(Object.keys(display).length === 0){
         inputs.forEach(input => {
             var newDisplay = {...display}
@@ -14,7 +15,7 @@ export default function MembershipForm({inputs, name, record, setRecord}) {
             setDisplay(newDisplay)})
       }
      
-  },[display, inputs, name])
+    },[display, inputs, name])
 
     const editDisplay = (input, visible) => {
         var newDisplay ={...display}
@@ -37,8 +38,11 @@ export default function MembershipForm({inputs, name, record, setRecord}) {
     })
 
     return (
-        <div className='ml-3 fade-in'>
-            {questions}
-        </div>
-    )
+      <div className='ml-3 fade-in'>
+        {allowImport && (
+          <ImportButtonGroup/>
+        )}
+        {questions}
+      </div>
+    );
 }

--- a/src/components/formGroup/RatingInput.js
+++ b/src/components/formGroup/RatingInput.js
@@ -15,7 +15,7 @@ export default function RatingInput({input,name, setRecord , record}) {
       
             <Form.Group>
                 <Form.Label inline>What is your {input} rating?{' '}</Form.Label>
-                <input type='number' min={500} max={3200} className='form-rating-input' onChange={updateRecord} />
+                <input type='number' min={500} max={3200} className='form-rating-input' onChange={updateRecord} value={record[name][input]}/>
         </Form.Group>
         
     )

--- a/src/styles/Form.css
+++ b/src/styles/Form.css
@@ -23,9 +23,23 @@
     margin-bottom: 28px;
 }
 
-.question, .ratingInput{
+.question, .ratingInput, .import-container {
     margin-left: 40px;
   }
+
+.import-container {
+    width: 30vw;
+    display: flex;
+    column-gap: 20px;
+}
+
+.import-container input {
+    min-width: 200px;
+}
+
+.import-button-separator {
+    padding: 15px 0 15px 15vw;
+}
 
   .form-rating-input {
       display: inline ;


### PR DESCRIPTION
This uses the [chess API wrapper ](https://www.npmjs.com/package/chess-web-api) to retrieve player stats and automatically fill in input boxes based on the results.  

I had some trouble running the Flask app backend so these changes were only tested with the UI and should be further tested with the server running. 