### PR TITLE
When sharing, Elo should not be in all caps

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <meta property="og:title" content="Chess Rating Comparison" />
-    <meta property="og:description" content="Chess Ratign Comparison is used for chess players to compare Elo and Glicko ratings between multipls online platforms and organizations"/>
+    <meta property="og:description" content="Chess Rating Comparison is used for chess players to compare Elo and Glicko ratings between multiple online platforms and organizations"/>
     <meta property="og:image" content="https://i.ibb.co/N3tzmrz/OGImage.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/index.html
+++ b/public/index.html
@@ -17,11 +17,11 @@
   <!-- End Google Tag Manager -->
     <meta
       name="description"
-      content="Chess Rating Comparison is used for chess players to compare ELO and Glicko ratings between FIDE, USCF, LiChess, and Chess.com"
+      content="Chess Rating Comparison is used for chess players to compare Elo and Glicko ratings between FIDE, USCF, LiChess, and Chess.com"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <meta property="og:title" content="Chess Rating Comparison" />
-    <meta property="og:description" content="Chess Ratign Comparison is used for chess players to compare ELO and Glicko ratings between multipls online platforms and organizations"/>
+    <meta property="og:description" content="Chess Ratign Comparison is used for chess players to compare Elo and Glicko ratings between multipls online platforms and organizations"/>
     <meta property="og:image" content="https://i.ibb.co/N3tzmrz/OGImage.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
I recently shared a link to the site and this is what I got:

<img width="450" alt="Screenshot 2022-10-28 at 7 58 58 AM" src="https://user-images.githubusercontent.com/1469385/198595109-801afa0b-a136-473f-ae32-c43572cc2d30.png">

I fixed 2 things:

1. `ELO` should be `Elo`. It is named after the creator of the system so it is a name. Having it in all caps is a common mistake. Source: https://en.wikipedia.org/wiki/Elo_rating_system
2. There were 2 other spelling mistakes: `Ratign` and `multipls`